### PR TITLE
PYMT-1734 Hasher compatibility with string algorithms as per PHP 7.4 BC

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   "license": "BSD-3-Clause",
   "type": "library",
   "require": {
-    "php": ">=7.1",
+    "php": ">=7.4",
     "ext-dom": "*",
     "ext-json": "*",
     "ext-libxml": "*"

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   "license": "BSD-3-Clause",
   "type": "library",
   "require": {
-    "php": ">=7.4",
+    "php": ">=7.1",
     "ext-dom": "*",
     "ext-json": "*",
     "ext-libxml": "*"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -20,3 +20,6 @@ parameters:
         -
             message: '/Parameter #1 \$app of class EoneoPay\\Utils\\Bridge\\Lumen\\Providers\\ConfigurationServiceProvider constructor expects Illuminate\\Contracts\\Foundation\\Application, Mockery\\LegacyMockInterface given./'
             path: 'tests/Bridge/Lumen/Providers/ConfigurationServiceProviderTest.php'
+        -
+            message: '/Parameter #2 \$algo of function password_hash expects int, int\|string given\./'
+            path: 'src/Hasher.php'

--- a/src/Hasher.php
+++ b/src/Hasher.php
@@ -11,22 +11,22 @@ class Hasher implements HasherInterface
     /**
      * Algorithm constant value compatible with PHP's password hashing function
      *
-     * @var int
+     * @var string
      */
-    private $algorithm;
+    private string $algorithm;
 
     /**
      * @var mixed[]
      */
-    private $options;
+    private array $options;
 
     /**
      * Hasher constructor.
      *
-     * @param int|null $algorithm
+     * @param string|null $algorithm
      * @param mixed[]|null $options
      */
-    public function __construct(?int $algorithm = null, ?array $options = null)
+    public function __construct(?string $algorithm = null, ?array $options = null)
     {
         $this->algorithm = $algorithm ?? self::DEFAULT_ALGORITHM;
         $this->options = $options ?? [];

--- a/src/Hasher.php
+++ b/src/Hasher.php
@@ -13,12 +13,12 @@ class Hasher implements HasherInterface
      *
      * @var string|int
      */
-    private string $algorithm;
+    private $algorithm;
 
     /**
      * @var mixed[]
      */
-    private array $options;
+    private $options;
 
     /**
      * Hasher constructor.

--- a/src/Hasher.php
+++ b/src/Hasher.php
@@ -11,7 +11,7 @@ class Hasher implements HasherInterface
     /**
      * Algorithm constant value compatible with PHP's password hashing function
      *
-     * @var string
+     * @var string|int
      */
     private string $algorithm;
 
@@ -23,10 +23,10 @@ class Hasher implements HasherInterface
     /**
      * Hasher constructor.
      *
-     * @param string|null $algorithm
+     * @param string|int|null $algorithm
      * @param mixed[]|null $options
      */
-    public function __construct(?string $algorithm = null, ?array $options = null)
+    public function __construct($algorithm = null, ?array $options = null)
     {
         $this->algorithm = $algorithm ?? self::DEFAULT_ALGORITHM;
         $this->options = $options ?? [];

--- a/src/Interfaces/HasherInterface.php
+++ b/src/Interfaces/HasherInterface.php
@@ -8,7 +8,7 @@ interface HasherInterface
     /**
      * Algorithm to be used for hashing
      *
-     * @var int
+     * @var string
      */
     public const DEFAULT_ALGORITHM = \PASSWORD_BCRYPT;
 

--- a/src/Interfaces/HasherInterface.php
+++ b/src/Interfaces/HasherInterface.php
@@ -8,7 +8,7 @@ interface HasherInterface
     /**
      * Algorithm to be used for hashing
      *
-     * @var string
+     * @var string|int
      */
     public const DEFAULT_ALGORITHM = \PASSWORD_BCRYPT;
 


### PR DESCRIPTION
Support for int|string for algorithm so that new and old PHP versions are supported, since the 7.4 BC
https://www.php.net/manual/en/migration74.incompatible.php
See "Password algorithm constants"